### PR TITLE
Allow React 17 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.1",
+    "react": ">=16.8.1  <18",
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
React 17 should not break this package, this PR simply adds React 17 to the allowed peer dependencies.